### PR TITLE
Fixes to enable building on msvc

### DIFF
--- a/src/cmt.h
+++ b/src/cmt.h
@@ -22,6 +22,10 @@
 #ifndef CMT_BASE_INCLUDED
 #define CMT_BASE_INCLUDED
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338327
+#endif
+
 /*****************************************************************************/
 
 #include "ladspa_types.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -114,6 +114,10 @@ static StartupShutdownHandler g_oStartupShutdownHandler;
   
 /*****************************************************************************/
 
+#ifdef _MSC_VER
+// needed to get it to compile on msvc
+__declspec(dllexport)
+#endif
 const LADSPA_Descriptor * 
 ladspa_descriptor(unsigned long Index) {
   if (Index < g_lPluginCount)


### PR DESCRIPTION
Added a `M_PI` macro to enable building on msvc. Very minor change, easy merge.