### PR TITLE
Fixes to CMT plugins runtime crash on MSVC

### DIFF
--- a/src/cmt.h
+++ b/src/cmt.h
@@ -138,7 +138,10 @@ protected:
     : m_ppfPorts(new LADSPA_Data_ptr[lPortCount]) {
   }
   virtual ~CMT_PluginInstance() {
-    delete [] m_ppfPorts;
+    if (m_ppfPorts != nullptr){
+      delete [] m_ppfPorts;
+      m_ppfPorts = nullptr; // set pointer to nullptr after deletion
+    }
   }
 
   friend void CMT_ConnectPort(LADSPA_Handle Instance,


### PR DESCRIPTION
CMT plugins were causing a heap corruption overflow because of attempts to delete already delete data. The code before was crash prone due to double deletion. I would be upstreaming this change.